### PR TITLE
Update pipeline with resource_types

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -100,3 +100,17 @@ resources:
   type: slack-notification
   source:
     url: {{slack-webhook-url}}
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+- name: 18f-bosh-deployment
+  type: docker-image
+  source:
+    repository: 18fgsa/bosh-deployment-resource
+- name: cg-common
+  type: docker-image
+  source:
+    repository: 18fgsa/cg-common-resource


### PR DESCRIPTION
For review, make non built-in resource types explicit, rather than relying on them being installed in Concourse. Has been fly'd.
@18F/cloud-gov-ops
