### PR TITLE
Remove trigger deployments for production

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -53,10 +53,10 @@ jobs:
   - aggregate:
     - get: pipeline-tasks
     - get: admin-ui-config-production
-      trigger: true
-    - get: admin-ui-release
       trigger: false
       passed: [deploy-admin-ui-staging]
+    - get: admin-ui-release
+      trigger: false
     - get: common-prod
     - get: admin-ui-stemcell
   - task: admin-ui-manifest


### PR DESCRIPTION
This patch removes the `trigger: true` for the
admin-ui-config-production. This is because the
`deploy-admin-ui-staging` now automatically deploys production if it
passes. This is all done to avoid needing to create PRs / merge from
staging to master in the repository.

Pairing with @sushiandbeer 
