### PR TITLE
Drop releases from runtime config.

### DIFF
--- a/admin-ui-deployment.yml
+++ b/admin-ui-deployment.yml
@@ -11,24 +11,6 @@ director_uuid: (( param "specify director uuid" ))
 releases:
 - name: admin-ui
   version: latest
-- name: collectd
-  version: latest
-- name: fisma
-  version: latest
-- name: tripwire
-  version: latest
-- name: clamav
-  version: latest
-- name: snort
-  version: latest
-- name: riemannc
-  version: latest
-- name: awslogs
-  version: latest
-- name: nessus-agent
-  version: latest
-- name: newrelic
-  version: latest
 compilation: (( param "specify compilation" ))
 update: (( param "specify update" ))
 
@@ -56,24 +38,6 @@ jobs:
   templates:
   - name: admin_ui
     release: admin-ui
-  - name: collectd
-    release: collectd
-  - name: harden
-    release: fisma
-  - name: tripwire
-    release: tripwire
-  - name: clamav
-    release: clamav
-  - name: snort
-    release: snort
-  - name: riemannc
-    release: riemannc
-  - name: awslogs
-    release: awslogs
-  - name: nessus-agent
-    release: nessus-agent
-  - name: newrelic-monitor
-    release: newrelic
   instances: 1
   resource_pool: medium_z1
   persistent_disk_pool: admin-ui
@@ -109,17 +73,6 @@ properties:
     url: (( param "specify uaa url" ))
     admin:
       client_secret: (( param "specify uaa client secret" ))
-  tripwire: (( param "specify tripwire properties" ))
-  awslogs: (( param "specify awslogs properties" ))
-  nessus-agent: (( param "specify nessus properties" ))
-  newrelic: (( param "specify newrelic properties" ))
-  collectd:
-    riemann_server: (( param "specify riemann host" ))
-    hostname_prefix: (( param "specify collectd prefix" ))
-
-  riemann:
-    server: (( grab properties.collectd.riemann_server ))
-    port: 5555
   admin_ui:
     cloud_controller_uri: (( grab properties.cc.srv_api_uri ))
     cloud_controller_ssl_verify_none: (( grab properties.ssl.skip_cert_verify ))

--- a/secrets.example.yml
+++ b/secrets.example.yml
@@ -4,10 +4,10 @@ meta:
   subdomain: "admin"
   admin_ui_uaa_client:
     id: "admin-ui"
-    secret: SECRET 
+    secret: SECRET
   network: default
 
-director_uuid: DIRECTOR_ID 
+director_uuid: DIRECTOR_ID
 
 compilation:
   cloud_properties:
@@ -39,17 +39,14 @@ resource_pools:
 networks:
 - cloud_properties:
     security_groups: SECURITY_GROUP
-    subnet: SUBNET_ID 
+    subnet: SUBNET_ID
   name: default
   type: dynamic
 
 properties:
-  cc: 
+  cc:
     srv_api_uri: CC_API_URL
   system_domain: CC_DOMAIN
-  collectd:
-    riemann_server: RIEMANN_DNS
-    hostname_prefix: "cf.admin-ui."
   uaa:
     url: UAA_URL
     admin:
@@ -65,7 +62,7 @@ properties:
     - NAT_1
     - NAT-2
     port: 4222
-  databases: 
+  databases:
     db_scheme: postgres
     address: DB_ADDRESS
     port: 5432
@@ -76,4 +73,3 @@ properties:
       ccadmin:
         password: SECRET
         username: USERNAME
-


### PR DESCRIPTION
Now that hardening and logging releases are part of the bosh runtime config, we can start dropping them from deployments. Depends on https://github.com/18F/cg-deploy-bosh/pull/38.