### PR TITLE
Refactor and cruft cleanup for bosh2, cloud-config

### DIFF
--- a/admin-ui-deployment.yml
+++ b/admin-ui-deployment.yml
@@ -1,11 +1,4 @@
 ---
-meta:
-  network: cf1
-  subdomain: admin
-  admin_ui_uaa_client:
-    id: admin-ui
-    secret: (( param "specify uaa client secret" ))
-
 name: admin-ui
 director_uuid: (( param "specify director uuid" ))
 releases:
@@ -19,7 +12,7 @@ stemcells:
   version: latest
 
 instance_groups:
-- name: admin_ui
+- name: admin-ui
   instances: 1
   azs: [z1]
   networks:
@@ -27,56 +20,55 @@ instance_groups:
   vm_type: admin-ui
   persistent_disk_type: admin-ui
   stemcell: default
-  templates:
+  jobs:
   - name: admin_ui
     release: admin-ui
+    properties:
+      cc:
+        srv_api_uri: (( param "specify cc api url" ))
+      system_domain: (( param "specify system domain" ))
+      uaa:
+        url: (( param "specify uaa url" ))
+        admin:
+          client_secret: (( param "specify uaa client secret" ))
+      admin_ui:
+        cloud_controller_uri: (( grab instance_groups.admin-ui.jobs.admin_ui.properties.cc.srv_api_uri ))
+        cloud_controller_ssl_verify_none: (( grab instance_groups.admin-ui.jobs.admin_ui.properties.ssl.skip_cert_verify ))
+        uri: (( concat "admin." instance_groups.admin-ui.jobs.admin_ui.properties.system_domain ))
+        users: ~
+        admins: (( param "specify admins" ))
+        uaa:
+          url: (( grab instance_groups.admin-ui.jobs.admin_ui.properties.uaa.url ))
+          admin_client_secret: (( grab instance_groups.admin-ui.jobs.admin_ui.properties.uaa.admin.client_secret ))
+          client:
+            id: admin-ui
+            secret: (( param "specify uaa client secret" ))
+          scopes:
+            admin: ~
+            user: ~
 
-properties:
-  cc:
-    srv_api_uri: (( param "specify cc api url" ))
-  system_domain: (( param "specify system domain" ))
-  uaa:
-    url: (( param "specify uaa url" ))
-    admin:
-      client_secret: (( param "specify uaa client secret" ))
-  admin_ui:
-    cloud_controller_uri: (( grab properties.cc.srv_api_uri ))
-    cloud_controller_ssl_verify_none: (( grab properties.ssl.skip_cert_verify ))
-    uri: (( concat meta.subdomain "." properties.system_domain ))
-    users: ~
-    admins: (( param "specify admins" ))
-    uaa:
-      url: (( grab properties.uaa.url ))
-      admin_client_secret: (( grab properties.uaa.admin.client_secret ))
-      client:
-        id: (( grab meta.admin_ui_uaa_client.id ))
-        secret: (( grab meta.admin_ui_uaa_client.secret ))
-      scopes:
-        admin: ~
-        user: ~
+        ccdb:
+          scheme: (( grab terraform_outputs.cf_rds_engine ))
+          address: (( grab terraform_outputs.cf_rds_host ))
+          port: (( grab terraform_outputs.cf_rds_port ))
+          username: (( grab terraform_outputs.cf_rds_username ))
+          password: (( grab terraform_outputs.cf_rds_password ))
+          database: ccdb
+        uaadb:
+          scheme: (( grab terraform_outputs.cf_rds_engine ))
+          address: (( grab terraform_outputs.cf_rds_host ))
+          port: (( grab terraform_outputs.cf_rds_port ))
+          username: (( grab terraform_outputs.cf_rds_username ))
+          password: (( grab terraform_outputs.cf_rds_password ))
+          database: uaadb
 
-    ccdb:
-      scheme: (( grab terraform_outputs.cf_rds_engine ))
-      address: (( grab terraform_outputs.cf_rds_host ))
-      port: (( grab terraform_outputs.cf_rds_port ))
-      username: (( grab terraform_outputs.cf_rds_username ))
-      password: (( grab terraform_outputs.cf_rds_password ))
-      database: ccdb
-    uaadb:
-      scheme: (( grab terraform_outputs.cf_rds_engine ))
-      address: (( grab terraform_outputs.cf_rds_host ))
-      port: (( grab terraform_outputs.cf_rds_port ))
-      username: (( grab terraform_outputs.cf_rds_username ))
-      password: (( grab terraform_outputs.cf_rds_password ))
-      database: uaadb
-
-  ssl:
-    skip_cert_verify: false
-  networks:
-    apps: (( grab meta.network ))
-  nats:
-    user: (( param "specify nats user" ))
-    password: (( param "specify nats password" ))
-    port: (( param "specify nats port" ))
-    machines: (( param "specify nats machines" ))
-    address: (( grab machines.[0] ))
+      ssl:
+        skip_cert_verify: false
+      networks:
+        apps: (( param "specify apps network" ))
+      nats:
+        user: (( param "specify nats user" ))
+        password: (( param "specify nats password" ))
+        port: (( param "specify nats port" ))
+        machines: (( param "specify nats machines" ))
+        address: (( grab machines.[0] ))

--- a/secrets.example.yml
+++ b/secrets.example.yml
@@ -1,23 +1,4 @@
-meta:
-  aws:
-    availability_zone: us-east-1
-  subdomain: "admin"
-  admin_ui_uaa_client:
-    id: "admin-ui"
-    secret: SECRET
-  network: default
-
 director_uuid: DIRECTOR_ID
-
-compilation:
-  cloud_properties:
-    availability_zone: us-east-1b
-    disk: 20000
-    instance_type: c3.large
-    persistent_disk: 20000
-  network: default
-  reuse_compilation_vms: true
-  workers: 3
 
 update:
   canaries: 1
@@ -26,50 +7,39 @@ update:
   serial: true
   update_watch_time: 5000-600000
 
-resource_pools:
-- cloud_properties:
-    instance_type: t2.medium
-    availability_zone: (( meta.aws.availability_zone ))
-  name: medium_z1
-  network: default
-  stemcell:
-    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: latest
-
-networks:
-- cloud_properties:
-    security_groups: SECURITY_GROUP
-    subnet: SUBNET_ID
-  name: default
-  type: dynamic
-
-properties:
-  cc:
-    srv_api_uri: CC_API_URL
-  system_domain: CC_DOMAIN
-  uaa:
-    url: UAA_URL
-    admin:
-      client_secret: SECRET
-  admin_ui:
-    admins:
-    - admin
-  nats:
-    user: nats
-    password: nats
-    address: NATS_IP
-    machines:
-    - NAT_1
-    - NAT-2
-    port: 4222
-  databases:
-    db_scheme: postgres
-    address: DB_ADDRESS
-    port: 5432
-    roles:
-      uaaadmin:
-        password: SECRET
-        username: USERNAME
-      ccadmin:
-        password: SECRET
-        username: USERNAME
+instance_groups:
+- name: admin-ui
+  jobs:
+  - name: admin_ui
+    properties:
+      cc:
+        srv_api_uri: CC_API_URL
+      system_domain: CC_DOMAIN
+      uaa:
+        url: UAA_URL
+        admin:
+          client_secret: SECRET
+      admin_ui:
+        admins:
+        - admin
+        uaa:
+          client:
+            secret: SECRET
+      networks:
+        apps: cf1
+      nats:
+        user: nats
+        password: nats
+        address: NATS_IP
+        machines:
+        - NAT_1
+        - NAT-2
+        port: 4222
+      databases:
+        roles:
+          uaaadmin:
+            password: SECRET
+            username: USERNAME
+          ccadmin:
+            password: SECRET
+            username: USERNAME


### PR DESCRIPTION
- Re-parent global properties to the job they correspond, updated spruce grabs
- Yank unnecessary `meta`, place those direct in properties as they were singletons
- Remove cloud-config derived bits from `secrets.example.yml`
- Fully passes linting
```
$ ./generate-manifest.sh terraform-state.yml secrets.yml > manifest.yml

$ bosh-lint lint-manifest manifest.yml
Problem  Context  Resolution

0 suggestions

Succeeded
```
/cc @jmcarp 