### PR TITLE
Use supported bosh deployment resource.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -16,7 +16,6 @@ jobs:
       trigger: true
     - get: terraform-yaml
       resource: terraform-yaml-staging
-    - get: master-bosh-root-cert
   - task: admin-ui-manifest
     config: &manifest-config
       platform: linux
@@ -48,7 +47,6 @@ jobs:
       lint-manifest: admin-manifest
   - put: admin-ui-staging-deployment
     params: &deploy-params
-      cert: master-bosh-root-cert/master-bosh.crt
       manifest: admin-manifest/manifest.yml
       releases:
       - admin-ui-release/*.tgz
@@ -92,7 +90,6 @@ jobs:
       trigger: true
     - get: terraform-yaml
       resource: terraform-yaml-production
-    - get: master-bosh-root-cert
   - task: admin-ui-manifest
     config:
       <<: *manifest-config
@@ -134,13 +131,6 @@ jobs:
       icon_url: {{slack-icon-url}}
 
 resources:
-- name: master-bosh-root-cert
-  type: s3-iam
-  source:
-    bucket: {{admin-ui-private-bucket-production}}
-    region_name: {{aws-region}}
-    versioned_file: master-bosh.crt
-
 - name: common-staging
   type: cg-common
   source:
@@ -182,22 +172,22 @@ resources:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
 
 - name: admin-ui-staging-deployment
-  type: 18f-bosh-deployment
+  type: bosh-deployment
   source:
     target: {{admin-ui-staging-deployment-bosh-target}}
-    username: {{admin-ui-staging-deployment-bosh-username}}
-    password: {{admin-ui-staging-deployment-bosh-password}}
+    client: {{admin-ui-staging-deployment-bosh-client}}
+    client_secret: {{admin-ui-staging-deployment-bosh-client-secret}}
     deployment: {{admin-ui-staging-deployment-bosh-deployment}}
-    ignore_ssl: false
+    ca_cert: {{admin-ui-staging-deployment-ca-cert}}
 
 - name: admin-ui-production-deployment
-  type: 18f-bosh-deployment
+  type: bosh-deployment
   source:
     target: {{admin-ui-production-deployment-bosh-target}}
-    username: {{admin-ui-production-deployment-bosh-username}}
-    password: {{admin-ui-production-deployment-bosh-password}}
+    client: {{admin-ui-production-deployment-bosh-client}}
+    client_secret: {{admin-ui-production-deployment-bosh-client-secret}}
     deployment: {{admin-ui-production-deployment-bosh-deployment}}
-    ignore_ssl: false
+    ca_cert: {{admin-ui-staging-deployment-ca-cert}}
 
 - name: pipeline-tasks
   type: git
@@ -235,10 +225,10 @@ resource_types:
   source:
     repository: 18fgsa/s3-resource
 
-- name: 18f-bosh-deployment
+- name: bosh-deployment
   type: docker-image
   source:
-    repository: 18fgsa/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
 
 - name: cg-common
   type: docker-image


### PR DESCRIPTION
Use https://github.com/cloudfoundry/bosh-deployment-resource instead of our unmaintained fork of the previous unmaintained resource. This switches to bosh-cli v2.