### PR TITLE
Auto-detect director uuid.

### DIFF
--- a/admin-ui-deployment.yml
+++ b/admin-ui-deployment.yml
@@ -1,8 +1,6 @@
 ---
 name: admin-ui
 
-director_uuid: (( param "specify director uuid" ))
-
 releases:
 - name: admin-ui
   version: latest

--- a/admin-ui-production.yml
+++ b/admin-ui-production.yml
@@ -1,6 +1,4 @@
 ---
-director_uuid: 32ce257a-6086-45ce-9c1f-48fdfc509fe1
-
 instance_groups:
 - name: admin-ui
   jobs:

--- a/admin-ui-staging.yml
+++ b/admin-ui-staging.yml
@@ -1,6 +1,4 @@
 ---
-director_uuid: dee45f8d-3b79-49f6-90e9-956ab91fc4cc
-
 instance_groups:
 - name: admin-ui
   jobs:


### PR DESCRIPTION
Because BOSH knows how to detect it.