### PR TITLE
Use create-swap-delete strategy for updates

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -13,6 +13,7 @@ update:
   max_in_flight: 1
   serial: true
   update_watch_time: 5000-600000
+  vm_strategy: create-swap-delete
 
 stemcells:
 - alias: default


### PR DESCRIPTION
Normally, bosh deletes a vm, then creates its replacement. Using
the create-delete-swap vm_strategy, the new vm is made, then
traffic is moved over to it, then the old one is deleted.
More details: https://bosh.io/docs/changing-deployment-vm-strategy/