### PR TITLE
vm cannot update due to full disk

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -28,7 +28,7 @@ instance_groups:
   - name: default
   vm_type: t3.medium
   vm_extensions: [admin-lb]
-  persistent_disk_type: 5GB
+  persistent_disk_type: 10GB
   stemcell: default
   jobs:
   - name: secureproxy


### PR DESCRIPTION
## Changes proposed in this pull request:

Increases the persistent disk size. The current stemcell update is failing on a full disk

## security considerations

none
